### PR TITLE
Fix loaded nulls

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure(2) do |config|
   config.vm.network :forwarded_port, guest: 9090, host: 9090
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
   end
 
   config.vm.provision :puppet do |puppet|

--- a/cqlmapper/models.py
+++ b/cqlmapper/models.py
@@ -409,6 +409,7 @@ class BaseModel(object):
     def _set_persisted(self):
         for v in self._values.values():
             v.reset_previous_value()
+            v.explicit = False
         self._is_persisted = True
 
     def _can_update(self):

--- a/cqlmapper/models.py
+++ b/cqlmapper/models.py
@@ -403,11 +403,12 @@ class BaseModel(object):
         klass = cls
 
         instance = klass(**values)
-        instance._set_persisted()
+        instance._set_persisted(force=True)
         return instance
 
-    def _set_persisted(self):
-        for v in self._values.values():
+    def _set_persisted(self, force=False):
+        # ensure we don't modify to any values not affected by the last save/update
+        for v in [v for v in self._values.values() if v.changed or force]:
             v.reset_previous_value()
             v.explicit = False
         self._is_persisted = True

--- a/puppet/modules/cassandra/manifests/init.pp
+++ b/puppet/modules/cassandra/manifests/init.pp
@@ -29,7 +29,7 @@ class cassandra {
   }
 
   package { 'cassandra':
-    ensure  => "2.2.7",
+    ensure  => "2.2.8",
     require => Class['cassandra::java'],
   }
 


### PR DESCRIPTION
Currently, when you load a model from the database, it ends up setting `explicit = True` on all of the values which means that `model._values['column'].deleted` resolves to `True` when you load null values from the database.  As a result, cqlmapper issues a `DELETE` query for all of the null values that you loaded, creating a tombstone for each one when you don't need one.

This PR ports two updates from cqlengine that address this issue:

https://github.com/datastax/python-driver/commit/589c15abeee37667824c270d8fc3db69912f63e8
https://github.com/datastax/python-driver/commit/99cc8e83a0edc662808b509ec328d889b85c72c5