### PR TITLE
Add load_many method to the BaseModel object

### DIFF
--- a/cqlmapper/models.py
+++ b/cqlmapper/models.py
@@ -685,7 +685,7 @@ class BaseModel(object):
             keys = [{pks[0]: value} for value in keys]
 
         parameters = [tuple(key_values[key] for key in pks) for key_values in keys]
-        args_str = " ".join("{key} = ?".format(key) for key in pks)
+        args_str = " AND ".join("{key} = ?".format(key=key) for key in pks)
         statement = conn.session.prepare(
             "SELECT * FROM {cf_name} WHERE {args}".format(
                 cf_name=cls.column_family_name(), args=args_str

--- a/cqlmapper/models.py
+++ b/cqlmapper/models.py
@@ -645,14 +645,14 @@ class BaseModel(object):
 
                 class ComplexModel(Model):
                     pk = columns.Text(primary_key=True)  # partition key
-                    ck = colums.Integer(primary_key=True)  # clustering
+                    ck = columns.Integer(primary_key=True)  # clustering
                     value = columns.Text()
 
                 valid_simple = SimpleModel.load_many(conn, ["fizz", "buzz"])
                 valid_simple = SimpleModel.load_many(conn, [{"key": "fizz"}, {"key: "buzz"}])
                 try:
                     invalid_simple = SimpleModel.load_many(conn, ["fizz", {"key: "buzz"}])
-                except TypeError:
+                except Exception:
                     pass
 
                 valid_complex = ComplexModel.load_many(
@@ -664,7 +664,7 @@ class BaseModel(object):
                 )
                 try:
                     invalid_complex = SimpleModel.load_many(conn, [{"pk": "fizz"}])
-                except ValueError:
+                except Exception:
                     pass
 
         :type: List[Dict[str, Any]] or List[Any]

--- a/cqlmapper/models.py
+++ b/cqlmapper/models.py
@@ -688,8 +688,7 @@ class BaseModel(object):
         args_str = " ".join("{key} = ?".format(key) for key in pks)
         statement = conn.session.prepare(
             "SELECT * FROM {cf_name} WHERE {args}".format(
-                cf_name=cls.column_family_name(),
-                args=args_str,
+                cf_name=cls.column_family_name(), args=args_str
             )
         )
         results = execute_concurrent_with_args(
@@ -708,7 +707,9 @@ class BaseModel(object):
                     values = values._asdict()
                 elif not isinstance(values, dict):
                     # The 'tuple' row factory is not supported
-                    raise TypeError("The type returned by 'session.execute' must be a dict or a namedtuple")
+                    raise TypeError(
+                        "The type returned by 'session.execute' must be a dict or a namedtuple"
+                    )
                 models.append(cls._construct_instance(values))
         return models
 

--- a/cqlmapper/models.py
+++ b/cqlmapper/models.py
@@ -20,6 +20,7 @@ from warnings import warn
 
 import six
 
+from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.metadata import protect_name
 from cassandra.util import OrderedDict
 
@@ -623,6 +624,117 @@ class BaseModel(object):
 
     def _execute_query(self, conn, q):
         return conn.execute(q)
+
+    @classmethod
+    def load_many(cls, conn, keys, concurrency=25):
+        """Load multiple models concurrently.
+
+        :param conn: Cassandra connection wrapper used to execute the query.
+        :type: cqlengine.ConnectionInterface subclass
+        :param keys: List of PRIMARY KEY values to load models by.  For simple
+            models with only a single PRIMARY KEY (single partition key and no
+            clustering keys) a simple list of values may be used.  For cases with
+            multiple PRIMARY KEYS, a list of dicts mapping each primary key to
+            it's value must be given.
+
+            .. code-block:: python
+
+                class SimpleModel(Model):
+                    key = columns.Text(primary_key=True)
+                    value = columns.Text()
+
+                class ComplexModel(Model):
+                    pk = columns.Text(primary_key=True)
+                    ck = colums.Integer(primary_key=True)
+                    value = columns.Text()
+
+                valid_simple = SimpleModel.load_many(conn, ["fizz", "buzz"])
+                valid_simple = SimpleModel.load_many(conn, [{"key": "fizz"}, {"key, "buzz"}])
+                try:
+                    invalid_simple = SimpleModel.load_many(conn, ["fizz", {"key, "buzz"}])
+                except TypeError:
+                    pass
+
+                valid_complex = ComplexModel.load_many(
+                    conn=conn,
+                    keys=[
+                        {"pk": "fizz", "ck": "buzz},
+                        {"pk", "foo", "ck": "bar"},
+                    ],
+                )
+                try:
+                    invalid_complex = SimpleModel.load_many(conn, [{"pk": "fizz"}])
+                except ValueError:
+                    pass
+
+        :type: List[Dict[str, Any]] or List[Any]
+        :param concurrency: Maximum number of queries to run concurrently.
+        :type: int
+        """
+        if not keys:
+            return []
+
+        if concurrency < 1:
+            raise ValueError("'concurrency' in 'load_many' must be >= 1.")
+
+        # cls._primary_keys is an OrderedDict so no need to sort the keys
+        pks = list(cls._primary_keys.keys())
+
+        # Validate that 'keys' is either all dicts or all simple values for
+        # Models that allow that
+        simple_keys = False
+        parameters = []
+        for i, key_values in enumerate(keys):
+            if not isinstance(key_values, dict) and len(pks) == 1 and i == 0:
+                simple_keys = True
+
+            if simple_keys:
+                if isinstance(key_values, dict):
+                    raise TypeError(
+                        "'keys' has a mix of dicts and simple values, must be "
+                        "one or the other for model %s." % cls.__name__
+                    )
+                parameters.append((key_values,))
+            else:
+                if not isinstance(key_values, dict):
+                    raise TypeError(
+                        "All values in 'keys' must be a dict for model %s." % cls.__name__
+                    )
+                else:
+                    try:
+                        parameters.append(tuple(keys[key] for key in pks))
+                    except KeyError:
+                        raise ValueError(
+                            "An element in 'keys' is missing a PRIMARY KEY "
+                            "value for model %s." % cls.__name__
+                        )
+
+        args_str = " ".join("{key} = ?".format(key) for key in pks)
+        statement = conn.session.prepare(
+            "SELECT * FROM {cf_name} WHERE {args}".format(
+                cf_name=cls.column_family_name(),
+                args=args_str,
+            )
+        )
+        results = execute_concurrent_with_args(
+            session=conn.session,
+            statement=statement,
+            parameters=parameters,
+            concurrency=concurrency,
+        )
+        models = []
+        for result in results:
+            if not result.success:
+                raise result.result_or_exc
+            for values in result.result_or_exc:
+                if isinstance(values, tuple) and hasattr(values, "_asdict"):
+                    # Support the default 'row_factory' which returns a namedtuple
+                    values = values._asdict()
+                elif not isinstance(values, dict):
+                    # The 'tuple' row factory is not supported
+                    raise TypeError("The type returned by 'session.execute' must be a dict or a namedtuple")
+                models.append(cls._construct_instance(values))
+        return models
 
     def save(self, conn):
         """Saves an object to the database.

--- a/cqlmapper/models.py
+++ b/cqlmapper/models.py
@@ -649,9 +649,9 @@ class BaseModel(object):
                     value = columns.Text()
 
                 valid_simple = SimpleModel.load_many(conn, ["fizz", "buzz"])
-                valid_simple = SimpleModel.load_many(conn, [{"key": "fizz"}, {"key, "buzz"}])
+                valid_simple = SimpleModel.load_many(conn, [{"key": "fizz"}, {"key: "buzz"}])
                 try:
-                    invalid_simple = SimpleModel.load_many(conn, ["fizz", {"key, "buzz"}])
+                    invalid_simple = SimpleModel.load_many(conn, ["fizz", {"key: "buzz"}])
                 except TypeError:
                     pass
 


### PR DESCRIPTION
Add an `@classmethod` to `BaseModel` that allows you to load multiple models concurrently using `execute_concurrent_with_args`.